### PR TITLE
fix deploy-commands

### DIFF
--- a/src/deployCommands.ts
+++ b/src/deployCommands.ts
@@ -17,15 +17,16 @@ const rest = new REST().setToken(config.token);
 (async () => {
     console.log(commandsPath);
     for (const file of commandsFiles) {
-        const filePath = join(commandsPath, file);
-        const {commands} = await import(filePath);
-        for (const command of commands) {
-            if (command.global) {
-                globalCommandArray.push(command.data.toJSON());
-            } else {
-                guildCommandArray.push(command.data.toJSON());
+        const filePath = `file://${join(commandsPath, file)}`;
+        await import(filePath).then(commands => {
+            for (const command of commands.default) {
+                if (command.global) {
+                    globalCommandArray.push(command.data.toJSON());
+                } else {
+                    guildCommandArray.push(command.data.toJSON());
+                }
             }
-        }
+        });
     }
 
     try {


### PR DESCRIPTION
- ``deployCommands.ts``がWindowsで動作しない問題を修正
- ``deployCommands.ts``においてコマンド登録ができない問題を修正

各コマンドは default export でお願いします
windowsで動くようにしたのでLinuxでの動作確認をお願いします